### PR TITLE
move introduction of help teams to a separate page and add contact information

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -51,6 +51,9 @@ const permaTitle = 'Hacking in Parallel 2022 //// Berlin'
 						<a href='/coc/'>CoC</a>
 					</li>
 					<li>
+						<a href='/help/'>Help</a>
+					</li>
+					<li>
 						<a
 							href='https://engelsystem.hip-berlin.de/'
 							target='_blank'

--- a/src/pages/coc/index.astro
+++ b/src/pages/coc/index.astro
@@ -46,17 +46,8 @@ import Layout from '../../layouts/Layout.astro'
 			<p>
 				If you are unable to solve a problem, or if you feel you should not solve a problem yourself, then maybe others around you can help.  If not, then let a volunteer know immediately.
 			</p>
-			<h3>
-				The following is a more detailed introduction to teams that make HiP-Berlin a safe, secure, enjoyable, and open event for all
-			</h3>
 			<p>
-				The Awareness Team provides a point of contact for people to process experiences, resolve conflicts, and to create a safe and enjoyable atmosphere for all.
-			</p>
-			<p>
-				The Safety and Security Team is tasked with preventing behavioral conflicts and their escalation.  This team is also responsible for preventing hazards.  They are a friendly and firm reminder of our principles.  They may expel misbehaving lifeforms if an exceptional situation warrants it.
-			</p>
-			<p>
-				The CERT (Chaos Emergency Response Team) consists of people who will help in case of sickness and minor injuries, and will call professional help if needed.  The CERT provides aid in all situations and emergencies that require professional attention.  The CERT is also tasked with fire prevention, as well as ensuring that escape path codes are observed.
+				Check out the <a href='/help/'>Help</a> page for a more detailed introduction of the teams that make HiP-Berlin a safe, secure, enjoyable, and open event for all.
 			</p>
 		</article>
 	</main>

--- a/src/pages/help/index.astro
+++ b/src/pages/help/index.astro
@@ -1,0 +1,38 @@
+---
+import Layout from '../../layouts/Layout.astro'
+---
+
+<Layout title='help'>
+	<main>
+		<article>
+			<h1>Help</h1>
+			<p>
+				Do you feel unwell, require medical support, experienced discrimination or conflicts? We are there for you! These  are the teams you can reach out to to get help.
+			</p>
+
+			<h3>Awareness</h3>
+			<p>
+				DECT: AWRE (2973)
+			</p>
+			<p>
+				The Awareness Team provides a point of contact for people to process experiences, resolve conflicts, and to create a safe and enjoyable atmosphere for all.
+			</p>
+
+			<h3>Safety and Security Team</h3>
+			<p>
+				DECT: SECU (7328)
+			</p>
+			<p>
+				The Safety and Security Team is tasked with preventing behavioral conflicts and their escalation.  This team is also responsible for preventing hazards.  They are a friendly and firm reminder of our principles.  They may expel misbehaving lifeforms if an exceptional situation warrants it.
+			</p>
+
+			<h3>CERT</h3>
+			<p>
+				DECT: CERT (2378)
+			</p>
+			<p>
+				The CERT (Chaos Emergency Response Team) consists of people who will help in case of sickness and minor injuries, and will call professional help if needed.  The CERT provides aid in all situations and emergencies that require professional attention.  The CERT is also tasked with fire prevention, as well as ensuring that escape path codes are observed.
+			</p>
+		</article>
+	</main>
+</Layout>

--- a/src/pages/help/index.astro
+++ b/src/pages/help/index.astro
@@ -7,12 +7,18 @@ import Layout from '../../layouts/Layout.astro'
 		<article>
 			<h1>Help</h1>
 			<p>
-				Do you feel unwell, require medical support, experienced discrimination or conflicts? We are there for you! These  are the teams you can reach out to to get help.
+				Do you feel unwell, require medical support, experienced discrimination or conflicts? We are there for you! These are the teams you can reach out to to get help.
 			</p>
 
 			<h3>Awareness</h3>
 			<p>
-				DECT: AWRE (2973)
+				DECT: AWRE (2973)<br/>
+				Matrix: <a
+					href='https://matrix.to/#/#HiP-Awareness-Public:milliways.info'
+					title='HiP 2022 public Awareness Team Channel'
+					rel='noopener noreferrer'
+					target='_blank'
+					>#HiP-Awareness-Public</a>
 			</p>
 			<p>
 				The Awareness Team provides a point of contact for people to process experiences, resolve conflicts, and to create a safe and enjoyable atmosphere for all.


### PR DESCRIPTION
contact information was missing completely so far and this info as well as the team descriptions should be easier to find, so a separate page seems preferable over the end of the CoC